### PR TITLE
DC 883 Help for Test CLI does not list available test groups

### DIFF
--- a/tests/DoctrineTest.php
+++ b/tests/DoctrineTest.php
@@ -125,7 +125,8 @@ class DoctrineTest
 
         //show help text
         if (isset($options['help'])) {
-            $availableGroups = sort(array_keys($this->groups));	
+            $availableGroups = array_keys($this->groups);
+            sort($availableGroups);
 	
             echo "Doctrine test runner help\n";
             echo "===========================\n";


### PR DESCRIPTION
The CLI Test Runner is supposed to print a list of available test groups when used with the --help parameter, but this fails as the Doctrine_Test::run() method erroneously expects php sort() to return an array rather than a boolean. Fixed in this commit
