### PR TITLE
DC 880 - Foreign keys created and dropped when using Versionable and Searchable behaviours and migration building from YAML

### DIFF
--- a/lib/Doctrine/AuditLog.php
+++ b/lib/Doctrine/AuditLog.php
@@ -43,7 +43,7 @@ class Doctrine_AuditLog extends Doctrine_Record_Generator
                                                              'type'   => 'integer',
                                                              'length' => 8,
                                                              'options' => array('primary' => true)),
-                                'tableName'         => false,
+                                'tableName'        => '%TABLE%_Version',
                                 'generateFiles'     => false,
                                 'table'             => false,
                                 'pluginTable'       => false,

--- a/lib/Doctrine/Migration/Diff.php
+++ b/lib/Doctrine/Migration/Diff.php
@@ -111,7 +111,9 @@ class Doctrine_Migration_Diff
     {
         $this->_cleanup();
 
-        $from = $this->_generateModels(self::$_fromPrefix, $this->_from);
+        $from = $this->_generateModels(
+            Doctrine_Manager::getInstance()->getAttribute(Doctrine_Core::ATTR_MODEL_CLASS_PREFIX) . self::$_fromPrefix, 
+			$this->_from);
         $to = $this->_generateModels(
             Doctrine_Manager::getInstance()->getAttribute(Doctrine_Core::ATTR_MODEL_CLASS_PREFIX) . self::$_toPrefix,
             $this->_to

--- a/lib/Doctrine/Search.php
+++ b/lib/Doctrine/Search.php
@@ -41,6 +41,7 @@ class Doctrine_Search extends Doctrine_Record_Generator
                                 'analyzer_options' => array(),
                                 'type'             => self::INDEX_TABLES,
                                 'className'        => '%CLASS%Index',
+                                'tableName'        => '%TABLE%_Index',
                                 'generatePath'     => false,
                                 'table'            => null,
                                 'batchUpdates'     => false,

--- a/lib/Doctrine/Search.php
+++ b/lib/Doctrine/Search.php
@@ -41,7 +41,7 @@ class Doctrine_Search extends Doctrine_Record_Generator
                                 'analyzer_options' => array(),
                                 'type'             => self::INDEX_TABLES,
                                 'className'        => '%CLASS%Index',
-                                'tableName'        => '%TABLE%_Index',
+                                'tableName'        => '%TABLE%_index',
                                 'generatePath'     => false,
                                 'table'            => null,
                                 'batchUpdates'     => false,

--- a/lib/Doctrine/Template/Versionable.php
+++ b/lib/Doctrine/Template/Versionable.php
@@ -45,7 +45,7 @@ class Doctrine_Template_Versionable extends Doctrine_Template
                                                              'length' => 8,
                                                              'options' => array()),
 								'generateRelations' => true,
-                                'tableName'         => false,
+                                'tableName'        => '%TABLE%_Version',
                                 'generateFiles'     => false,
                                 'auditLog'          => true,
                                 'deleteVersions'    => true,

--- a/lib/Doctrine/Template/Versionable.php
+++ b/lib/Doctrine/Template/Versionable.php
@@ -45,7 +45,7 @@ class Doctrine_Template_Versionable extends Doctrine_Template
                                                              'length' => 8,
                                                              'options' => array()),
 								'generateRelations' => true,
-                                'tableName'        => '%TABLE%_Version',
+                                'tableName'        => '%TABLE%_version',
                                 'generateFiles'     => false,
                                 'auditLog'          => true,
                                 'deleteVersions'    => true,

--- a/tests/Ticket/DC755/dc755_from.yml
+++ b/tests/Ticket/DC755/dc755_from.yml
@@ -1,0 +1,3 @@
+755Test:
+  columns:
+    test_col: {type: integer}

--- a/tests/Ticket/DC755/dc755_to.yml
+++ b/tests/Ticket/DC755/dc755_to.yml
@@ -1,0 +1,3 @@
+755Test:
+  columns:
+    test_col: {type: string(25)}

--- a/tests/Ticket/DC755TestCase.php
+++ b/tests/Ticket/DC755TestCase.php
@@ -1,0 +1,60 @@
+<?php
+/*
+ *  $Id$
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the LGPL. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+/**
+ * Doctrine_Ticket_DC755_TestCase
+ *
+ * @package     Doctrine
+ * @author      Andrew Coulton <andrew.coulton@proscenia.co.uk>
+ * @license     http://www.opensource.org/licenses/lgpl-license.php LGPL
+ * @category    Object Relational Mapping
+ * @link        www.doctrine-project.org
+ * @since       1.0
+ * @version     $Revision$
+ */
+class Doctrine_Ticket_DC755_TestCase extends Doctrine_UnitTestCase 
+{
+	protected $driverName = 'Mysql';
+		
+	public function testYAMLYAMLMigrationsWithPrefix() {
+		$manager = Doctrine_Manager::getInstance();
+	
+		$oldPrefix = $manager->getAttribute(Doctrine_Core::ATTR_MODEL_CLASS_PREFIX);
+		$manager->setAttribute(Doctrine_Core::ATTR_MODEL_CLASS_PREFIX, 'Model_Test');
+		
+		$dir = dirname(__FILE__) . '/DC755/migrations';
+        if ( ! is_dir($dir)) {
+            mkdir($dir, 0777, true);
+        }
+        $migration = new Doctrine_Migration($dir);
+		
+		$diff = new Doctrine_Migration_Diff(dirname(__FILE__) . '/DC755/dc755_from.yml', dirname(__FILE__) . '/DC755/dc755_to.yml', $migration);
+		$changes =  $diff->generateChanges();
+		
+		$this->assertTrue(isset($changes['changed_columns']['755_test']['test_col']));
+		$this->assertFalse(isset($changes['created_tables']['755_test']));
+		$this->assertFalse(isset($changes['dropped_tables']['755_test']));
+		
+		$manager->setAttribute(Doctrine_Core::ATTR_MODEL_CLASS_PREFIX, $oldPrefix);
+	}
+	
+
+}

--- a/tests/Ticket/DC880/dc880_schema.yml
+++ b/tests/Ticket/DC880/dc880_schema.yml
@@ -1,0 +1,46 @@
+## YAML Schema for testing migration when behaviours are present
+880Versionable:
+  actAs:
+    Versionable:
+      versionColumn: version
+      className: %CLASS%Version
+      auditLog: true
+
+880Timestampable:
+  actAs:
+    Timestampable: true
+
+880Sluggable:
+  columns:
+    test: string(255)
+  actAs:
+    Sluggable:
+      unique: true
+      fields: [test]
+      canUpdate: true
+
+880I18n:
+  columns:
+    test: string(255)
+  actAs:
+    I18n:
+      fields: [test]
+
+880NestedSet:
+  actAs:
+    NestedSet: true
+
+880Searchable:
+  columns:
+    test: string(255)
+  actAs:
+    Searchable:
+      fields: [test]
+
+880Geographical:
+  actAs:
+    Geographical: true
+
+880SoftDelete:
+  actAs:
+    SoftDelete: true

--- a/tests/Ticket/DC880TestCase.php
+++ b/tests/Ticket/DC880TestCase.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ *  $Id$
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the LGPL. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+/**
+ * Doctrine_Ticket_DC880_TestCase
+ *
+ * @package     Doctrine
+ * @author      Andrew Coulton <andrew.coulton@proscenia.co.uk>
+ * @license     http://www.opensource.org/licenses/lgpl-license.php LGPL
+ * @category    Object Relational Mapping
+ * @link        www.doctrine-project.org
+ * @since       1.0
+ * @version     $Revision$
+ */
+class Doctrine_Ticket_DC880_TestCase extends Doctrine_UnitTestCase
+{
+
+    protected $driverName = 'Mysql';
+
+    public function testMigrationWithBehavioursNotAddingUnexpectedChanges()
+    {
+        $manager = Doctrine_Manager::getInstance();
+
+        $oldPrefix = $manager->getAttribute(Doctrine_Core::ATTR_MODEL_CLASS_PREFIX);
+        $manager->setAttribute(Doctrine_Core::ATTR_MODEL_CLASS_PREFIX, 'Model_Test_DC880');
+
+        $dir = dirname(__FILE__) . '/DC880/migrations';
+        if (!is_dir($dir))
+        {
+            mkdir($dir, 0777, true);
+        }
+        $migration = new Doctrine_Migration($dir);
+
+        $diff = new Doctrine_Migration_Diff(dirname(__FILE__) . '/DC880/dc880_schema.yml',
+                                            dirname(__FILE__) . '/DC880/dc880_schema.yml',
+                                            $migration);
+
+        $changes = $diff->generateChanges();
+        
+        $foundChanges = array();
+        foreach ($changes as $kind=>$models) {
+            if (count($models)) {
+                $foundChanges[$kind] = implode(',', array_keys($models));
+            }
+        }
+
+        $this->assertEqual($foundChanges, array());
+
+        $manager->setAttribute(Doctrine_Core::ATTR_MODEL_CLASS_PREFIX, $oldPrefix);
+    }
+
+}


### PR DESCRIPTION
I've experienced similar problems to the OP of DC-880 where building migrations from two identical YAML files, with model prefixing in use, generates a set of drop and create index/foreign key actions relating to the behaviour table. I think this is because the versionable behaviour doesn't define a table name in the Doctrine_Template_Versionable class (nor searchable in its own). As a result, if using model prefixes, the prefixes are not discarded from the table names when the behaviour model classes are built. This means that the tables have different names to what is expected, so they have different index keys, so the indexes are dropped and recreated as part of the migration.

I have committed unit tests and patch for this issue. I believe the values of tableName provided will be consistent with the previous dynamic table names, so there should be no BC break.

This fix has a dependency on my earlier fix to DC-755 as without that fix migrations with model prefixing don't work at all.
