### PR TITLE
Ticket Test 1674 fails on windows machines

### DIFF
--- a/lib/Doctrine/AuditLog.php
+++ b/lib/Doctrine/AuditLog.php
@@ -43,7 +43,7 @@ class Doctrine_AuditLog extends Doctrine_Record_Generator
                                                              'type'   => 'integer',
                                                              'length' => 8,
                                                              'options' => array('primary' => true)),
-                                'tableName'         => false,
+                                'tableName'        => '%TABLE%_Version',
                                 'generateFiles'     => false,
                                 'table'             => false,
                                 'pluginTable'       => false,

--- a/lib/Doctrine/Migration/Diff.php
+++ b/lib/Doctrine/Migration/Diff.php
@@ -111,7 +111,9 @@ class Doctrine_Migration_Diff
     {
         $this->_cleanup();
 
-        $from = $this->_generateModels(self::$_fromPrefix, $this->_from);
+        $from = $this->_generateModels(
+            Doctrine_Manager::getInstance()->getAttribute(Doctrine_Core::ATTR_MODEL_CLASS_PREFIX) . self::$_fromPrefix, 
+			$this->_from);
         $to = $this->_generateModels(
             Doctrine_Manager::getInstance()->getAttribute(Doctrine_Core::ATTR_MODEL_CLASS_PREFIX) . self::$_toPrefix,
             $this->_to

--- a/lib/Doctrine/Search.php
+++ b/lib/Doctrine/Search.php
@@ -41,6 +41,7 @@ class Doctrine_Search extends Doctrine_Record_Generator
                                 'analyzer_options' => array(),
                                 'type'             => self::INDEX_TABLES,
                                 'className'        => '%CLASS%Index',
+                                'tableName'        => '%TABLE%_Index',
                                 'generatePath'     => false,
                                 'table'            => null,
                                 'batchUpdates'     => false,

--- a/lib/Doctrine/Search.php
+++ b/lib/Doctrine/Search.php
@@ -41,7 +41,7 @@ class Doctrine_Search extends Doctrine_Record_Generator
                                 'analyzer_options' => array(),
                                 'type'             => self::INDEX_TABLES,
                                 'className'        => '%CLASS%Index',
-                                'tableName'        => '%TABLE%_Index',
+                                'tableName'        => '%TABLE%_index',
                                 'generatePath'     => false,
                                 'table'            => null,
                                 'batchUpdates'     => false,

--- a/lib/Doctrine/Template/Versionable.php
+++ b/lib/Doctrine/Template/Versionable.php
@@ -45,7 +45,7 @@ class Doctrine_Template_Versionable extends Doctrine_Template
                                                              'length' => 8,
                                                              'options' => array()),
 								'generateRelations' => true,
-                                'tableName'         => false,
+                                'tableName'        => '%TABLE%_Version',
                                 'generateFiles'     => false,
                                 'auditLog'          => true,
                                 'deleteVersions'    => true,

--- a/lib/Doctrine/Template/Versionable.php
+++ b/lib/Doctrine/Template/Versionable.php
@@ -45,7 +45,7 @@ class Doctrine_Template_Versionable extends Doctrine_Template
                                                              'length' => 8,
                                                              'options' => array()),
 								'generateRelations' => true,
-                                'tableName'        => '%TABLE%_Version',
+                                'tableName'        => '%TABLE%_version',
                                 'generateFiles'     => false,
                                 'auditLog'          => true,
                                 'deleteVersions'    => true,

--- a/tests/DoctrineTest.php
+++ b/tests/DoctrineTest.php
@@ -125,7 +125,8 @@ class DoctrineTest
 
         //show help text
         if (isset($options['help'])) {
-            $availableGroups = sort(array_keys($this->groups));	
+            $availableGroups = array_keys($this->groups);
+            sort($availableGroups);
 	
             echo "Doctrine test runner help\n";
             echo "===========================\n";

--- a/tests/Ticket/1674TestCase.php
+++ b/tests/Ticket/1674TestCase.php
@@ -43,8 +43,6 @@ class Doctrine_Ticket_1674_TestCase extends Doctrine_UnitTestCase
             ->execute();
 
         $xml = $users->exportTo('xml'); 
-        $this->assertEqual($xml, '<?xml version="1.0" encoding="utf-8"?>
-<data><User id="4" type="0" email_id="1"><name>zYne</name><loginname></loginname><password></password><created></created><updated></updated><Phonenumber><Phonenumber id="2" entity_id="4"><phonenumber>123 123</phonenumber><Entity></Entity></Phonenumber></Phonenumber></User></data>
-');
+        $this->assertEqual($xml, '<?xml version="1.0" encoding="utf-8"?>'."\n".'<data><User id="4" type="0" email_id="1"><name>zYne</name><loginname></loginname><password></password><created></created><updated></updated><Phonenumber><Phonenumber id="2" entity_id="4"><phonenumber>123 123</phonenumber><Entity></Entity></Phonenumber></Phonenumber></User></data>'."\n");
     }
 }

--- a/tests/Ticket/DC755/dc755_from.yml
+++ b/tests/Ticket/DC755/dc755_from.yml
@@ -1,0 +1,3 @@
+755Test:
+  columns:
+    test_col: {type: integer}

--- a/tests/Ticket/DC755/dc755_to.yml
+++ b/tests/Ticket/DC755/dc755_to.yml
@@ -1,0 +1,3 @@
+755Test:
+  columns:
+    test_col: {type: string(25)}

--- a/tests/Ticket/DC755TestCase.php
+++ b/tests/Ticket/DC755TestCase.php
@@ -1,0 +1,60 @@
+<?php
+/*
+ *  $Id$
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the LGPL. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+/**
+ * Doctrine_Ticket_DC755_TestCase
+ *
+ * @package     Doctrine
+ * @author      Andrew Coulton <andrew.coulton@proscenia.co.uk>
+ * @license     http://www.opensource.org/licenses/lgpl-license.php LGPL
+ * @category    Object Relational Mapping
+ * @link        www.doctrine-project.org
+ * @since       1.0
+ * @version     $Revision$
+ */
+class Doctrine_Ticket_DC755_TestCase extends Doctrine_UnitTestCase 
+{
+	protected $driverName = 'Mysql';
+		
+	public function testYAMLYAMLMigrationsWithPrefix() {
+		$manager = Doctrine_Manager::getInstance();
+	
+		$oldPrefix = $manager->getAttribute(Doctrine_Core::ATTR_MODEL_CLASS_PREFIX);
+		$manager->setAttribute(Doctrine_Core::ATTR_MODEL_CLASS_PREFIX, 'Model_Test');
+		
+		$dir = dirname(__FILE__) . '/DC755/migrations';
+        if ( ! is_dir($dir)) {
+            mkdir($dir, 0777, true);
+        }
+        $migration = new Doctrine_Migration($dir);
+		
+		$diff = new Doctrine_Migration_Diff(dirname(__FILE__) . '/DC755/dc755_from.yml', dirname(__FILE__) . '/DC755/dc755_to.yml', $migration);
+		$changes =  $diff->generateChanges();
+		
+		$this->assertTrue(isset($changes['changed_columns']['755_test']['test_col']));
+		$this->assertFalse(isset($changes['created_tables']['755_test']));
+		$this->assertFalse(isset($changes['dropped_tables']['755_test']));
+		
+		$manager->setAttribute(Doctrine_Core::ATTR_MODEL_CLASS_PREFIX, $oldPrefix);
+	}
+	
+
+}

--- a/tests/Ticket/DC880/dc880_schema.yml
+++ b/tests/Ticket/DC880/dc880_schema.yml
@@ -1,0 +1,46 @@
+## YAML Schema for testing migration when behaviours are present
+880Versionable:
+  actAs:
+    Versionable:
+      versionColumn: version
+      className: %CLASS%Version
+      auditLog: true
+
+880Timestampable:
+  actAs:
+    Timestampable: true
+
+880Sluggable:
+  columns:
+    test: string(255)
+  actAs:
+    Sluggable:
+      unique: true
+      fields: [test]
+      canUpdate: true
+
+880I18n:
+  columns:
+    test: string(255)
+  actAs:
+    I18n:
+      fields: [test]
+
+880NestedSet:
+  actAs:
+    NestedSet: true
+
+880Searchable:
+  columns:
+    test: string(255)
+  actAs:
+    Searchable:
+      fields: [test]
+
+880Geographical:
+  actAs:
+    Geographical: true
+
+880SoftDelete:
+  actAs:
+    SoftDelete: true

--- a/tests/Ticket/DC880TestCase.php
+++ b/tests/Ticket/DC880TestCase.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ *  $Id$
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the LGPL. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+/**
+ * Doctrine_Ticket_DC880_TestCase
+ *
+ * @package     Doctrine
+ * @author      Andrew Coulton <andrew.coulton@proscenia.co.uk>
+ * @license     http://www.opensource.org/licenses/lgpl-license.php LGPL
+ * @category    Object Relational Mapping
+ * @link        www.doctrine-project.org
+ * @since       1.0
+ * @version     $Revision$
+ */
+class Doctrine_Ticket_DC880_TestCase extends Doctrine_UnitTestCase
+{
+
+    protected $driverName = 'Mysql';
+
+    public function testMigrationWithBehavioursNotAddingUnexpectedChanges()
+    {
+        $manager = Doctrine_Manager::getInstance();
+
+        $oldPrefix = $manager->getAttribute(Doctrine_Core::ATTR_MODEL_CLASS_PREFIX);
+        $manager->setAttribute(Doctrine_Core::ATTR_MODEL_CLASS_PREFIX, 'Model_Test_DC880');
+
+        $dir = dirname(__FILE__) . '/DC880/migrations';
+        if (!is_dir($dir))
+        {
+            mkdir($dir, 0777, true);
+        }
+        $migration = new Doctrine_Migration($dir);
+
+        $diff = new Doctrine_Migration_Diff(dirname(__FILE__) . '/DC880/dc880_schema.yml',
+                                            dirname(__FILE__) . '/DC880/dc880_schema.yml',
+                                            $migration);
+
+        $changes = $diff->generateChanges();
+        
+        $foundChanges = array();
+        foreach ($changes as $kind=>$models) {
+            if (count($models)) {
+                $foundChanges[$kind] = implode(',', array_keys($models));
+            }
+        }
+
+        $this->assertEqual($foundChanges, array());
+
+        $manager->setAttribute(Doctrine_Core::ATTR_MODEL_CLASS_PREFIX, $oldPrefix);
+    }
+
+}


### PR DESCRIPTION
SimpleXML always uses UNIX newlines but the TicketTestCase 1674 uses a two-line string to compare to a SimpleXML result which may have different line endings depending on the system. Have hardcoded \n into the test string to make this test pass cross-platform.
