### PR TITLE
Setting notnull to false in changeColumn() with psql

### DIFF
--- a/lib/Doctrine/Export/Pgsql.php
+++ b/lib/Doctrine/Export/Pgsql.php
@@ -159,7 +159,7 @@ class Doctrine_Export_Pgsql extends Doctrine_Export
                     $query = 'ALTER ' . $fieldName . ' SET DEFAULT ' . $this->conn->quote($field['definition']['default'], $field['definition']['type']);
                     $sql[] = 'ALTER TABLE ' . $this->conn->quoteIdentifier($name, true) . ' ' . $query;
                 }
-                if ( ! empty($field['definition']['notnull'])) {
+                if ( isset($field['definition']['notnull'])) {
                     $query = 'ALTER ' . $fieldName . ' ' . ($field['definition']['notnull'] ? 'SET' : 'DROP') . ' NOT NULL';
                     $sql[] = 'ALTER TABLE ' . $this->conn->quoteIdentifier($name, true) . ' ' . $query;
                 }


### PR DESCRIPTION
I have a column that I'd like to change from notnull->true to notnull->false, but the following doesn’t seem to work :

```
    $this->changeColumn('tbl_photo', 'user_id', 'integer', '8', array(
         'notnull' => 0,
         ));
```

It seems to be because in the following line :

```
  if ( ! empty($field['definition']['notnull'])) {
```

empty() in php returns true for 0, '', false etc, so it's not possible to set 'notnull' to false.
