### PR TITLE
Fixes for Taggable Extension + Fixes to prevent Fixtures overwrite when dump is performed

### DIFF
--- a/lib/Doctrine/Record/Generator.php
+++ b/lib/Doctrine/Record/Generator.php
@@ -152,6 +152,7 @@ abstract class Doctrine_Record_Generator extends Doctrine_Record_Abstract
 
         $ownerClassName = $this->_options['table']->getComponentName();
         $className = $this->_options['className'];
+        $ownerClassName = str_replace('_', '', $ownerClassName); // balupton: fixes pear style models Bal_Something
         $this->_options['className'] = str_replace('%CLASS%', $ownerClassName, $className);
 
         if (isset($this->_options['tableName'])) {
@@ -280,14 +281,14 @@ abstract class Doctrine_Record_Generator extends Doctrine_Record_Abstract
     {
         $fk = array();
 
-        foreach ((array) $table->getIdentifier() as $field) {
-            $def = $table->getDefinitionOf($field);
+        foreach ((array) $table->getIdentifier() as $column) {
+            $def = $table->getDefinitionOf($column);
 
             unset($def['autoincrement']);
             unset($def['sequence']);
             unset($def['primary']);
 
-            $col = $table->hasColumn($field) ? $field : $table->getColumnName($field) . ' as ' . $field;
+            $col = $column;
 
             $def['primary'] = true;
             $fk[$col] = $def;
@@ -431,7 +432,7 @@ abstract class Doctrine_Record_Generator extends Doctrine_Record_Abstract
         $definition['columns'] = $table->getColumns();
         $definition['tableName'] = $table->getTableName();
         $definition['actAs'] = $table->getTemplates();
-
+      
         return $this->generateClass($definition);
     }
 

--- a/lib/Doctrine/Task/DumpData.php
+++ b/lib/Doctrine/Task/DumpData.php
@@ -33,7 +33,7 @@
 class Doctrine_Task_DumpData extends Doctrine_Task
 {
     public $description          =   'Dump data to a yaml data fixture file.',
-           $requiredArguments    =   array('data_fixtures_path' =>  'Specify path to write the yaml data fixtures file to.',
+           $requiredArguments    =   array('data_dump_path'     =>  'Specify path to write the yaml data fixtures file to.',
                                            'models_path'        =>  'Specify path to your Doctrine_Record definitions.'),
            $optionalArguments    =   array();
 
@@ -45,7 +45,7 @@ class Doctrine_Task_DumpData extends Doctrine_Task
             throw new Doctrine_Task_Exception('No models were loaded'); 
         }
 
-        $path = $this->getArgument('data_fixtures_path');
+        $path = $this->getArgument('data_dump_path');
 
         if (is_array($path) && count($path) > 0) {
             $path = $path[0];
@@ -56,7 +56,7 @@ class Doctrine_Task_DumpData extends Doctrine_Task
 
             $this->notify(sprintf('Dumped data successfully to: %s', $path));
         } else {
-            throw new Doctrine_Task_Exception('Unable to find data fixtures path.');
+            throw new Doctrine_Task_Exception('Unable to find data dump path.');
         }
     }
 }


### PR DESCRIPTION
Contains two changes.

The change to "lib/Doctrine/Record/Generator.php" is for the Doctrine Taggable Extension to work properly:
https://github.com/balupton/Doctrine-Extension-Taggable

The change to "lib/Doctrine/Task/DumpData.php" is so the data_dump_path variable is actually used, and that the fixtures is not over-written.
