### PR TITLE
DC-864 Generating YAML schema from model picks up also some options

### DIFF
--- a/lib/Doctrine/Export/Schema.php
+++ b/lib/Doctrine/Export/Schema.php
@@ -126,6 +126,17 @@ class Doctrine_Export_Schema
                 }
             }
             
+            if ( isset( $data['options'] ) ) {
+                $options_to_export = array( 'charset', 'collate', 'queryParts' );
+                $options = array();
+                foreach( $options_to_export as $opt ) {
+                    if ( !isset( $data['options'][$opt] ) ) continue;
+                    if ( is_array($data['options'][$opt]) && empty($data['options'][$opt]) ) continue;
+                    $options[$opt] = $data['options'][$opt];
+                }
+                if (!empty($options)) $table['options'] = $options;
+            }
+            
             $array[$className] = $table;
         }
         

--- a/lib/Doctrine/Export/Schema.php
+++ b/lib/Doctrine/Export/Schema.php
@@ -125,6 +125,10 @@ class Doctrine_Export_Schema
                     $table['relations'][$relationKey]['type'] = 'one';
                 }
             }
+
+            if ( isset( $data['options']['indexes'] ) ) {
+                $table['indexes'] = $data['options']['indexes'];
+            }
             
             if ( isset( $data['options'] ) ) {
                 $options_to_export = array( 'charset', 'collate', 'queryParts' );


### PR DESCRIPTION
Options picked in YAML from PHP generation: charset, collate and queryParts
Otherwise they get lost, which makes difficult to use PHP models as a base for development (and I prefer them).

2011-01-10 added ability to include indexes as well
