### PR TITLE
Fix Floating point storage refrenced in #DC-949

### DIFF
--- a/lib/Doctrine/Core.php
+++ b/lib/Doctrine/Core.php
@@ -210,6 +210,8 @@ class Doctrine_Core
     const ATTR_MODEL_CLASS_PREFIX           = 178;
     const ATTR_TABLE_CLASS_FORMAT           = 179;
     const ATTR_MAX_IDENTIFIER_LENGTH        = 180;
+    const ATTR_USE_NATIVE_FLOAT				= 181;
+    const ATTR_USE_NATIVE_DOUBLE			= 182;
 
     /**
      * LIMIT CONSTANTS

--- a/lib/Doctrine/DataDict/Mysql.php
+++ b/lib/Doctrine/DataDict/Mysql.php
@@ -230,13 +230,23 @@ class Doctrine_DataDict_Mysql extends Doctrine_DataDict
             case 'timestamp':
                 return 'DATETIME';
             case 'float':
-                $length = !empty($field['length']) ? $field['length'] : 18;
-                $scale = !empty($field['scale']) ? $field['scale'] : $this->conn->getAttribute(Doctrine_Core::ATTR_DECIMAL_PLACES);
-                return 'FLOAT('.$length.', '.$scale.')';
+            	if($this->conn->getAttribute(Doctrine_Core::ATTR_USE_NATIVE_FLOAT))
+            	{
+           			return 'FLOAT';
+            	} else {
+                	$length = !empty($field['length']) ? $field['length'] : 18;
+                	$scale = !empty($field['scale']) ? $field['scale'] : $this->conn->getAttribute(Doctrine_Core::ATTR_DECIMAL_PLACES);
+            		return 'FLOAT('.$length.', '.$scale.')';
+            	}
             case 'double':
-                $length = !empty($field['length']) ? $field['length'] : 18;
-                $scale = !empty($field['scale']) ? $field['scale'] : $this->conn->getAttribute(Doctrine_Core::ATTR_DECIMAL_PLACES);
-                return 'DOUBLE('.$length.', '.$scale.')';
+            	if($this->conn->getAttribute(Doctrine_Core::ATTR_USE_NATIVE_DOUBLE))
+            	{
+            		return 'DOUBLE';
+            	} else {
+	            	$length = !empty($field['length']) ? $field['length'] : 18;
+	                $scale = !empty($field['scale']) ? $field['scale'] : $this->conn->getAttribute(Doctrine_Core::ATTR_DECIMAL_PLACES);
+	                return 'DOUBLE('.$length.', '.$scale.')';
+            	}
             case 'decimal':
                 $length = !empty($field['length']) ? $field['length'] : 18;
                 $scale = !empty($field['scale']) ? $field['scale'] : $this->conn->getAttribute(Doctrine_Core::ATTR_DECIMAL_PLACES);

--- a/lib/Doctrine/DataDict/Oracle.php
+++ b/lib/Doctrine/DataDict/Oracle.php
@@ -106,7 +106,13 @@ class Doctrine_DataDict_Oracle extends Doctrine_DataDict
             case 'timestamp':
                 return 'DATE';
             case 'float':
+            	if ($this->conn->getAttribute(Doctrine_Core::ATTR_USE_NATIVE_FLOAT)) {
+            		return 'FLOAT'; //return native form of float
+            	}
             case 'double':
+        		if ($this->conn->getAttribute(Doctrine_Core::ATTR_USE_NATIVE_DOUBLE)) {
+            		return 'DOUBLE'; //return native form of double
+            	}
                 return 'NUMBER';
             case 'decimal':
                 $scale = !empty($field['scale']) ? $field['scale'] : $this->conn->getAttribute(Doctrine_Core::ATTR_DECIMAL_PLACES);

--- a/lib/Doctrine/DataDict/Pgsql.php
+++ b/lib/Doctrine/DataDict/Pgsql.php
@@ -425,7 +425,13 @@ class Doctrine_DataDict_Pgsql extends Doctrine_DataDict
             case 'timestamp':
                 return 'TIMESTAMP';
             case 'float':
+            	if($this->conn->getAttribute(Doctrine_Core::ATTR_USE_NATIVE_FLOAT){
+            		return 'FLOAT(24)'; // native single precision float
+            	}
             case 'double':
+        		if($this->conn->getAttribute(Doctrine_Core::ATTR_USE_NATIVE_DOUBLE){
+            		return 'FLOAT(53)'; // native double precision float
+            	}
                 return 'FLOAT';
             case 'decimal':
                 $length = !empty($field['length']) ? $field['length'] : 18;
@@ -557,9 +563,19 @@ class Doctrine_DataDict_Pgsql extends Doctrine_DataDict
                 break;
             case 'float':
             case 'float4':
+            	if($this->conn->getAttribute(Doctrine_Core::ATTR_USE_NATIVE_FLOAT))
+            	{
+            		$type[] = 'float';
+            		break;
+            	}
             case 'float8':
             case 'double':
             case 'double precision':
+            	if($this->conn->getAttribute(Doctrine_Core::ATTR_USE_NATIVE_DOUBLE))
+            	{
+            		$type[] = 'double';
+            		break;
+            	}
             case 'real':
                 $type[] = 'float';
                 break;


### PR DESCRIPTION
This creates a new attribute constant Doctrine_Core::ATTR_USE_NATIVE_FLOAT and Doctrine_Core::ATTR_USE_NATIVE_DOUBLE. This will allow the setting of attributes of use_native_float = true and use_native_double = true. With these set to true in MySQL of the generated sql will no longer Make FLOAT(18,2) and will make it just FLOAT that is a true floating point the same thing with DOUBLE except it is now a true double precision floating point. 
Proper adjustments are also made to MySQL, Oracle and Postgresql to use native floating point declarations to define both single and double precision floating point data types. 
