### PR TITLE
$record->clearInvokedSaveHooks() not always called

### DIFF
--- a/lib/Doctrine/Connection/UnitOfWork.php
+++ b/lib/Doctrine/Connection/UnitOfWork.php
@@ -149,6 +149,7 @@ class Doctrine_Connection_UnitOfWork extends Doctrine_Connection_Module
         } catch (Exception $e) {
             // Make sure we roll back our internal transaction
             //$record->state($state);
+            $record->clearInvokedSaveHooks();
             $conn->rollback();
             throw $e;
         }


### PR DESCRIPTION
Fixed problem in Connection/UnitOfWork.php where $record->clearInvokedSaveHooks() was not being called if an exception occured.  This left circular references and caused free() on the record to be unsuccessful in making the memory free for garbage collection.
