### PR TITLE
Fix in import and query

### DIFF
--- a/lib/Doctrine/Import/Builder.php
+++ b/lib/Doctrine/Import/Builder.php
@@ -964,6 +964,9 @@ class Doctrine_Import_Builder extends Doctrine_Builder
         $className = $definition['className'];
         $extends = isset($definition['inheritance']['extends']) ? $definition['inheritance']['extends']:$this->_baseClassName;
 
+        if ( ! isset($definition['options']['comment']) && isset($definition['comment']))
+          $definition['options']['comment'] = $definition['comment'];
+
         if ( ! (isset($definition['no_definition']) && $definition['no_definition'] === true)) {
             $tableDefinitionCode = $this->buildTableDefinition($definition);
             $setUpCode = $this->buildSetUp($definition);

--- a/lib/Doctrine/Import/Schema.php
+++ b/lib/Doctrine/Import/Schema.php
@@ -123,7 +123,6 @@ class Doctrine_Import_Schema
                                                           'zerofill',
                                                           'owner',
                                                           'extra',
-                                                          'comment',
                                                           'charset',
                                                           'collation'),
 

--- a/lib/Doctrine/Query/Where.php
+++ b/lib/Doctrine/Query/Where.php
@@ -99,7 +99,7 @@ class Doctrine_Query_Where extends Doctrine_Query_Condition
 
             return $sql;
         } else {
-            return $where;
+            return $this->query->parseClause($where);
         }
     }
 


### PR DESCRIPTION
Extension in import - deep merge table options and global options.
Right usage 'comment' option on table-level, useful for mysql sql generation.
Bugfix in WHERE clause.

See more in demoproject at https://github.com/anton-ryzhov/symfony-patches
