### PR TITLE
[DC-1037] Quote identifiers when getting/setting Migration version

### DIFF
--- a/lib/Doctrine/Migration.php
+++ b/lib/Doctrine/Migration.php
@@ -226,9 +226,9 @@ class Doctrine_Migration
     public function setCurrentVersion($number)
     {
         if ($this->hasMigrated()) {
-            $this->_connection->exec("UPDATE " . $this->_migrationTableName . " SET version = $number");
+            $this->_connection->exec("UPDATE " . $this->_connection->quoteIdentifier($this->_migrationTableName, true) . " SET " . $this->_connection->quoteIdentifier('version', true) . " = $number");
         } else {
-            $this->_connection->exec("INSERT INTO " . $this->_migrationTableName . " (version) VALUES ($number)");
+            $this->_connection->exec("INSERT INTO " . $this->_connection->quoteIdentifier($this->_migrationTableName, true) . " (" . $this->_connection->quoteIdentifier('version', true) . ") VALUES ($number)");
         }
     }
 
@@ -241,7 +241,7 @@ class Doctrine_Migration
     {
         $this->_createMigrationTable();
 
-        $result = $this->_connection->fetchColumn("SELECT version FROM " . $this->_migrationTableName);
+        $result = $this->_connection->fetchColumn("SELECT " . $this->_connection->quoteIdentifier('version', true) . " FROM " . $this->_connection->quoteIdentifier($this->_migrationTableName, true));
 
         return isset($result[0]) ? $result[0]:0;
     }
@@ -255,7 +255,7 @@ class Doctrine_Migration
     {
         $this->_createMigrationTable();
 
-        $result = $this->_connection->fetchColumn("SELECT version FROM " . $this->_migrationTableName);
+        $result = $this->_connection->fetchColumn("SELECT " . $this->_connection->quoteIdentifier('version', true) . " FROM " . $this->_connection->quoteIdentifier($this->_migrationTableName, true));
 
         return isset($result[0]) ? true:false;
     }


### PR DESCRIPTION
This is a fix for ticket DC-1037:
http://www.doctrine-project.org/jira/browse/DC-1037

Without this patch, Migrations are fully broken for some databases (at least Oracle) when using quoted identifiers connection option.

This patch quotes identifiers used to generate raw SQL commands used in Doctrine_Migration.

I don't think this would present any type of backwards compatibility issues since we weren't quoting identifiers before, and there is no way to catch/modify the query before it is executed during the migration process.
