### PR TITLE
[NestedSet] fixed moving between trees

### DIFF
--- a/lib/Doctrine/Node/NestedSet.php
+++ b/lib/Doctrine/Node/NestedSet.php
@@ -608,11 +608,10 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
 
             // Set new root id for this node
             $this->setRootValue($newRoot);
-            $this->record->save();
-
             // Insert this node as a new node
             $this->setRightValue(0);
             $this->setLeftValue(0);
+            $this->record->save();
 
             switch ($moveType) {
                 case 'moveAsPrevSiblingOf':


### PR DESCRIPTION
When moving between trees the moved node `lft` and `rgt` values will be wrong. I think it is because the moved node root value saved (and `lft` and `rgt` not changed) before `shiftRlValues` is called (from the proper `insertXXX` function). This patch fix this issue.
