### PR TITLE
fixed Migrations for Oracle

### DIFF
--- a/lib/Doctrine/Migration.php
+++ b/lib/Doctrine/Migration.php
@@ -347,8 +347,9 @@ class Doctrine_Migration
                     return $to;
                 }
             } else {
-                $this->_connection->commit();
                 $this->setCurrentVersion($to);
+                $this->_connection->commit();
+                $this->_connection->commit();
                 return $to;
             }
         }


### PR DESCRIPTION
Migrations do not work for me in Oracle. Everything is applied correctly, but for the version table. Don't know that much about doctrine internals, but this fixed the problem.
