### PR TITLE
fixed 'ORA-01000: maximum open cursors exceeded' for batch tasks

### DIFF
--- a/lib/Doctrine/Connection/Statement.php
+++ b/lib/Doctrine/Connection/Statement.php
@@ -260,13 +260,21 @@ class Doctrine_Connection_Statement implements Doctrine_Adapter_Statement_Interf
             }
 
             $this->_conn->getListener()->postStmtExecute($event);
-
+            //fdorn, pguthy: 2011-07-04: fix maximum cursors exceeded with data-load
+			//Sometimes Selects appear here. SO close the startements.
+            if (substr($this->_stmt->queryString,0,6) != 'SELECT'){
+                $this->_stmt->closeCursor();
+            }
             return $result;
         } catch (PDOException $e) {
         } catch (Doctrine_Adapter_Exception $e) {
         }
-
+        
         $this->_conn->rethrowException($e, $this);
+
+        if (substr($this->_stmt->queryString,0,6) != 'SELECT'){
+            $this->_stmt->closeCursor();
+        }
 
         return false;
     }

--- a/lib/Doctrine/Hydrator/Graph.php
+++ b/lib/Doctrine/Hydrator/Graph.php
@@ -105,13 +105,16 @@ abstract class Doctrine_Hydrator_Graph extends Doctrine_Hydrator_Abstract
             } else {
                 $data = $stmt->fetch(Doctrine_Core::FETCH_ASSOC);
                 if ( ! $data) {
+                    $stmt->closeCursor();
+                    $this->flush();
                     return $result;
                 }
             }
             $activeRootIdentifier = null;
         } else { 
             $data = $stmt->fetch(Doctrine_Core::FETCH_ASSOC); 
-            if ( ! $data) { 
+            if ( ! $data) {
+                $stmt->closeCursor();
                 return $result; 
             }
         }
@@ -134,6 +137,8 @@ abstract class Doctrine_Hydrator_Graph extends Doctrine_Hydrator_Abstract
                 } else if ($activeRootIdentifier != $id[$rootAlias]) { 
                     // first row for the next record 
                     $this->_priorRow = $data; 
+                    $this->closeCursor();
+                    $this->flush();
                     return $result; 
                 } 
             }


### PR DESCRIPTION
I'm using doctrine+symfony. When loading "alot" data from yml (symfony doctrine:data-load) I get an "ORA-01000: maximum open cursors exceeded" exception.
An attempt to fix this has already been posted: https://github.com/doctrine/doctrine1/pull/26 however this was onyl a partial fix.
