### PR TITLE
Fix wrong filetype due to Unicode Character 'DELETE'  in comment.

### DIFF
--- a/lib/Doctrine/Manager.php
+++ b/lib/Doctrine/Manager.php
@@ -757,7 +757,7 @@ class Doctrine_Manager extends Doctrine_Configurable implements Countable, Itera
     /**
      * Register validators so that Doctrine is aware of them
      *
-     * @param  mixed $validators Name of validator or array of validators
+     * @param  mixed $validators Name of validator or array of validators
      * @return void
      */
     public function registerValidators($validators)


### PR DESCRIPTION
Steps to reproduce the problem:

``` shell
file Manager.php

Output:
Manager.php: data

Expexted output:
View.php: PHP script text
```

This bug affects all users of phpab (https://github.com/theseer/Autoload).
Manager.php will be ignored in the generated classmap.
