### PR TITLE
Fixes E_NOTICE when using array_diff with PHP 5.4

### DIFF
--- a/lib/Doctrine/Query/Abstract.php
+++ b/lib/Doctrine/Query/Abstract.php
@@ -1149,7 +1149,7 @@ abstract class Doctrine_Query_Abstract
         $copy->free();
 
         if ($componentsBefore !== $componentsAfter) {
-            return array_diff($componentsAfter, $componentsBefore);
+            return array_diff_assoc($componentsAfter, $componentsBefore);
         } else {
             return $componentsAfter;
         }


### PR DESCRIPTION
( ! ) Notice: Array to string conversion in lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Query/Abstract.php on line 1152
