### PR TITLE
Changing Statement::setFetchMode to only pass 1 parameter to PDO conditionally

### DIFF
--- a/lib/Doctrine/Connection/Statement.php
+++ b/lib/Doctrine/Connection/Statement.php
@@ -479,6 +479,11 @@ class Doctrine_Connection_Statement implements Doctrine_Adapter_Statement_Interf
      */
     public function setFetchMode($mode, $arg1 = null, $arg2 = null)
     {
-        return $this->_stmt->setFetchMode($mode, $arg1, $arg2);
+        // In PHP 5.3 PDO throws an Exception if the number of arguments exceeds 1 except for these three modes
+        if ($mode === Doctrine_Core::FETCH_COLUMN || $mode === Doctrine_Core::FETCH_FUNC || $mode === Doctrine_Core::FETCH_CLASS) {
+            return $this->_stmt->setFetchMode($mode, $arg1, $arg2);
+        } else {
+            return $this->_stmt->setFetchMode($mode);
+        }
     }
 }


### PR DESCRIPTION
Changing Statement::setFetchMode to only pass 1 parameter to PDO when the mode isn't in a defined list.  PDO throws an exception if it receives more than 1 parameter for most modes.  See:

https://bugs.php.net/bug.php?id=54545

and:

http://gcov.php.net/PHP_5_3/lcov_html/pdo/pdo_stmt.c.gcov.php (line 1454 begins the switch statement, line 1525 is the conditional before the exception)
