### PR TITLE
generic bugfix for http://www.doctrine-project.org/jira/browse/DC-207

### DIFF
--- a/lib/Doctrine/Connection/UnitOfWork.php
+++ b/lib/Doctrine/Connection/UnitOfWork.php
@@ -149,7 +149,12 @@ class Doctrine_Connection_UnitOfWork extends Doctrine_Connection_Module
         } catch (Exception $e) {
             // Make sure we roll back our internal transaction
             //$record->state($state);
-            $conn->rollback();
+            try {
+              $conn->rollback();
+            }
+            catch (Exception $ex) {
+              throw new Exception(sprintf('"%s" because "%s"', $ex->getMessage(), $e->getMessage()));
+            }
             throw $e;
         }
 


### PR DESCRIPTION
Before this commit, I was getting this message:
> Rollback failed. There is no active transaction.

Now, I get this message:
> "Rollback failed. There is no active transaction." because "SQLSTATE[HY000]: General error: 2006 MySQL server has gone away"