### PR TITLE
A bug in PHP 5.3.3 (and maybe other 5.3.x versions) caused this change.

### DIFF
--- a/lib/Doctrine/Connection/Statement.php
+++ b/lib/Doctrine/Connection/Statement.php
@@ -479,6 +479,14 @@ class Doctrine_Connection_Statement implements Doctrine_Adapter_Statement_Interf
      */
     public function setFetchMode($mode, $arg1 = null, $arg2 = null)
     {
-        return $this->_stmt->setFetchMode($mode, $arg1, $arg2);
+        if($arg1 != null && $arg2 != null) {
+            return $this->_stmt->setFetchMode($mode, $arg1, $arg2);
+        }
+        else if($arg1 != null) {
+            return $this->_stmt->setFetchMode($mode, $arg1);
+        }
+        else {
+            return $this->_stmt->setFetchMode($mode);
+        }
     }
 }


### PR DESCRIPTION
Reference: https://bugs.php.net/bug.php?id=54545

The change I made is to make sure that optional arguments are only supplied when necessary.

Tested and working in production.

Also, I searched the whole Doctrine 1.2.x codebase and made sure that this is the only place where the change is necessary.
