### PR TITLE
Not testing the right variable

### DIFF
--- a/lib/Doctrine/Connection/Mssql.php
+++ b/lib/Doctrine/Connection/Mssql.php
@@ -405,7 +405,7 @@ class Doctrine_Connection_Mssql extends Doctrine_Connection_Common
             $query = preg_replace($re, "\\1##{$key}##", $query, 1);
         }
         
-        $replacement = 'is_null($value) ? \'NULL\' : $this->quote($params[\\1])';
+        $replacement = 'is_null($params[\\1]) ? \'NULL\' : $this->quote($params[\\1])';
         $query = preg_replace('/##(\d+)##/e', $replacement, $query);
 
         return $query;


### PR DESCRIPTION
At this point, $value is the last value of the array. We should test every values, otherwise when the last value of our parameter array is null, all values are replaced by null.
