### PR TITLE
Doctrine.php not found

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,5 +15,8 @@
     },
     "autoload": {
         "psr-0": { "Doctrine_": "lib/" }
-    }
+    },
+    "include-path": [
+        "lib/"
+    ]
 }


### PR DESCRIPTION
When using Doctrine lib from composer I always get error "Doctrine.php" not found, because Doctrine lib is not in include path.

Solution - need to add "include-path" to composer.json file.
