### PR TITLE
Quote backslashes

### DIFF
--- a/lib/Doctrine/Formatter.php
+++ b/lib/Doctrine/Formatter.php
@@ -128,6 +128,7 @@ class Doctrine_Formatter extends Doctrine_Connection_Module
         $str = str_replace($tmp['end'],
             $tmp['escape'] .
             $tmp['end'], $str);
+        $str = str_replace('\\', '\\\\', $str);
 
         return $tmp['start'] . $str . $tmp['end'];
     }
@@ -188,7 +189,7 @@ class Doctrine_Formatter extends Doctrine_Connection_Module
         case 'enum':
         case 'set':
         case 'boolean':
-        return "'" . str_replace("'","''",$input) . "'";
+        return "'" . str_replace('\\', '\\\\', str_replace("'","''",$input)) . "'";
         }
     }
 

--- a/tests/Quote/MysqlTestCase.php
+++ b/tests/Quote/MysqlTestCase.php
@@ -1,0 +1,66 @@
+<?php
+/*
+ *  $Id$
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the LGPL. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+/**
+ * Doctrine_Ticket_1015_TestCase
+ *
+ * @package     Doctrine
+ * @license     http://www.opensource.org/licenses/lgpl-license.php LGPL
+ * @category    Object Relational Mapping
+ * @link        www.doctrine-project.org
+ * @since       1.0
+ * @version     $Revision$
+ */
+class Doctrine_Quote_Mysql_TestCase extends Doctrine_UnitTestCase {
+
+
+    protected function selectScalarTest ($input)
+    {
+        $quoted_input = $this->connection->quote($input);
+        $query = "SELECT {$quoted_input}";
+        $output = $this->connection->execute($query)->fetch(PDO::FETCH_COLUMN);
+        $this->assertEqual($input, $output);
+    }
+
+
+    public function testSimple ()
+    {
+        $this->selectScalarTest("foo");
+    }
+
+
+    public function testApostrophe ()
+    {
+        $this->selectScalarTest("foos'");
+    }
+
+
+    public function testBackslash ()
+    {
+        $this->selectScalarTest("foos\\");
+    }
+
+
+    public function testBackslashAndApostrophe ()
+    {
+        $this->selectScalarTest("foos\\'");
+    }
+}

--- a/tests/run.php
+++ b/tests/run.php
@@ -311,6 +311,11 @@ $nestedSet->addTestCase(new Doctrine_NestedSet_TimestampableMultiRoot_TestCase()
 $nestedSet->addTestCase(new Doctrine_NestedSet_Hydration_TestCase());
 $test->addTestCase($nestedSet);
 
+// Quoting Tests (not yet fully tested)
+$quote = new GroupTest('Quoting test', 'quote');
+$quote->addTestCase(new Doctrine_Quote_Mysql_TestCase());
+$test->addTestCase($quote);
+
 /*
 $unsorted = new GroupTest('Performance', 'performance');
 $unsorted->addTestCase(new Doctrine_Hydrate_Performance_TestCase());


### PR DESCRIPTION
(At least in MySQL and PostgreSQL) It is possible to do a SQL injection by passing `\'` in a string. It gets quoted as `\''`, but backslash escapes first quote and second one ends a string in SQL.

I tried to write test for that running `SELECT {$quoted_string}` query on database, but it returns empty array, even though it works fine, when I run the same code outside Doctrine unit tests, in my application. Help with that would be appreciated.
