### PR TITLE
BUGXIF : Query::fetchOne() instanciate the entire table...

### DIFF
--- a/lib/Doctrine/Query.php
+++ b/lib/Doctrine/Query.php
@@ -278,6 +278,11 @@ class Doctrine_Query extends Doctrine_Query_Abstract implements Countable
      */
     public function fetchOne($params = array(), $hydrationMode = null)
     {
+		if ( !count($this->getDqlPart('limit')) )
+		{
+			$this->limit( 1 );
+		}
+        
         $collection = $this->execute($params, $hydrationMode);
 
         if (is_scalar($collection)) {

--- a/lib/Doctrine/Query.php
+++ b/lib/Doctrine/Query.php
@@ -278,10 +278,10 @@ class Doctrine_Query extends Doctrine_Query_Abstract implements Countable
      */
     public function fetchOne($params = array(), $hydrationMode = null)
     {
-		if ( !count($this->getDqlPart('limit')) )
-		{
-			$this->limit( 1 );
-		}
+        if ( !count($this->getDqlPart('limit')) )
+        {
+            $this->limit( 1 );
+        }
         
         $collection = $this->execute($params, $hydrationMode);
 


### PR DESCRIPTION
Calling Doctrine_Query::create()->from('Model')->fetchOne() used to fetch the entire table and instanciate all rows in a Doctrine_Collection... And then just return first Record !

A big performance hole.

Fixed it.
