### PR TITLE
fix for compatibility with PHP 7

### DIFF
--- a/lib/Doctrine/Collection.php
+++ b/lib/Doctrine/Collection.php
@@ -460,7 +460,8 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
             $relations = $this->relation['table']->getRelations();
             foreach ($relations as $relation) {
                 if ($this->relation['class'] == $relation['localTable']->getOption('name') && $relation->getLocal() == $this->relation->getForeignFieldName()) {
-                    $record->$relation['alias'] = $this->reference;
+                    $alias          = $relation['alias'];
+                    $record->$alias = $this->reference;
                     break;
                 }
             }


### PR DESCRIPTION
Small fix for the compatibility with PHP 7 when using many-to-many relations configured with refClass.